### PR TITLE
Fix NPE when ModifyExpressionValue uses "CONSTANT" as a target

### DIFF
--- a/definition/src/main/java/org/sinytra/adapter/patch/transformer/dynfix/DynFixArbitraryInjectionPoint.java
+++ b/definition/src/main/java/org/sinytra/adapter/patch/transformer/dynfix/DynFixArbitraryInjectionPoint.java
@@ -12,6 +12,7 @@ import org.sinytra.adapter.patch.api.PatchAuditTrail;
 import org.sinytra.adapter.patch.transformer.operation.unit.ModifyInjectionPoint;
 import org.sinytra.adapter.patch.transformer.operation.unit.ModifyInjectionTarget;
 import org.sinytra.adapter.patch.util.AdapterUtil;
+import org.sinytra.adapter.patch.util.MethodQualifier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,7 +111,7 @@ public class DynFixArbitraryInjectionPoint implements DynamicFixer<DynFixArbitra
     private static MethodInsnNode findReplacementInjectionPoint(AbstractInsnNode lastInsn, UnaryOperator<AbstractInsnNode> flow, MethodContext methodContext) {
         // Require matching return types for ModifyExpressionValue mixins
         if (methodContext.methodAnnotation().matchesDesc(MixinConstants.MODIFY_EXPR_VAL)) {
-            Type desiredReturnType = Type.getReturnType(methodContext.getInjectionPointMethodQualifier().desc());
+            Type desiredReturnType = Type.getReturnType(methodContext.getMixinMethod().desc);
             return (MethodInsnNode) AdapterUtil.iterateInsns(lastInsn, flow, v -> v instanceof MethodInsnNode minsn && Type.getReturnType(minsn.desc).equals(desiredReturnType));
         } else {
             return (MethodInsnNode) AdapterUtil.iterateInsns(lastInsn, flow, v -> v instanceof MethodInsnNode);

--- a/test/src/test/java/org/sinytra/adapter/patch/test/mixin/DynamicMixinPatchTest.java
+++ b/test/src/test/java/org/sinytra/adapter/patch/test/mixin/DynamicMixinPatchTest.java
@@ -204,6 +204,11 @@ public class DynamicMixinPatchTest extends MinecraftMixinPatchTest {
             "isFarmlandNearWater",
             assertInjectionPoint()
         );
+        assertSameCode(
+                "org/sinytra/adapter/test/mixin/LivingEntityMixin",
+                "changeIFrames",
+                assertInjectionPoint()
+        );
     }
 
     @Test

--- a/test/src/testClasses/java/org/sinytra/adapter/test/mixin/LivingEntityMixin.java
+++ b/test/src/testClasses/java/org/sinytra/adapter/test/mixin/LivingEntityMixin.java
@@ -1,5 +1,8 @@
 package org.sinytra.adapter.test.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -11,6 +14,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
+    // https://github.com/Alexandra-Myers/Combatify/blob/1.21.1/src/main/java/net/atlas/combatify/mixin/InvulnerabilityMixin.java#L16
+    @ModifyExpressionValue(method = "hurt", at = @At(value = "CONSTANT", args = "intValue=20", ordinal = 0))
+    public int changeIFrames(int original, @Local(ordinal = 0, argsOnly = true) final DamageSource source, @Local(ordinal = 0, argsOnly = true) final float amount) {
+        return original;
+    }
+
+    @ModifyExpressionValue(method = "hurt", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/common/damagesource/DamageContainer;getPostAttackInvulnerabilityTicks()I"))
+    public int changeIFramesExpected(int original, @Local(ordinal = 0, argsOnly = true) final DamageSource source, @Local(ordinal = 0, argsOnly = true) final float amount) {
+        return original;
+    }
+
     // https://github.com/TheDeathlyCow/frostiful/blob/5f0a696400de2ae49b21ff42af5116f058cf13ae/src/main/java/com/github/thedeathlycow/frostiful/mixins/entity/ice_skating/LivingEntityMovementMixin.java#L141
     @ModifyVariable(
         method = "travel",


### PR DESCRIPTION
## The Issue

A `NullPointerException` is triggered when Adapter tries to patch a `ModifyExpressionValue` that uses "CONSTANT" as a target as it fails to find the value for `target()` in the at annotation within the call to `MethodContext.getInjectionPointMethodQualifier()`.

## The Proposal

As a `ModifyExpressionValue`'s return value for the mixin method *must* return the same as its target, rather than using the target's descriptor to get the expected return type, it should be expected to be equivalent to the return type for the mixin method. Therefore, the change is to use the mixin method's descriptor in order to ensure it is never null.

## Possible Side Effects

If it were somehow the case that the return type did not match the target for the `ModifyExpressionValue` it might be possible for this to cause incorrect behaviour, although it seems unlikely.

## Alternatives

I had considered instead finding some way to account for specifically the types of the target method, however after careful consideration I figured this solution out as it was far simpler and cleaner than checking what type the target returned.
