### PR TITLE
Fix crash when mixin target cannot be found

### DIFF
--- a/definition/src/main/java/org/sinytra/adapter/patch/transformer/dynfix/DynFixSyntheticInstanceof.java
+++ b/definition/src/main/java/org/sinytra/adapter/patch/transformer/dynfix/DynFixSyntheticInstanceof.java
@@ -37,7 +37,10 @@ public class DynFixSyntheticInstanceof implements DynamicFixer<DynFixSyntheticIn
             && methodContext.hasInjectionPointValue("INVOKE")
             && methodContext.findCleanInjectionTarget() != null && methodContext.findDirtyInjectionTarget() != null
         ) {
-            List<AbstractInsnNode> insns = methodContext.findInjectionTargetInsns(methodContext.findCleanInjectionTarget()); 
+            List<AbstractInsnNode> insns = methodContext.findInjectionTargetInsns(methodContext.findCleanInjectionTarget());
+            if (insns.isEmpty()) {
+                return null;
+            }
             return new Data(insns.getFirst());
         }
         return null;


### PR DESCRIPTION
## The Issue

Aims to fix this crash reported by a user: https://hst.sh/ewasamufid
It seems that when the returned list is empty, getFirst will throw a NoSuchElementException

## The Proposal

Skip transform if the target instruction cannot be found

## Possible Side Effects

None

## Alternatives

The check could be done elsewhere, but I think this is fine

## Additional Notes

None
