### PR TITLE
Fix ResolverSyntheticInstanceof incorrectly converting non-boolean ModifyExpressionValue to ModifyInstanceofValue

### DIFF
--- a/core/src/main/java/org/sinytra/adapter/patch/resolver/special/ResolverSyntheticInstanceof.java
+++ b/core/src/main/java/org/sinytra/adapter/patch/resolver/special/ResolverSyntheticInstanceof.java
@@ -1,6 +1,7 @@
 package org.sinytra.adapter.patch.resolver.special;
 
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 import org.sinytra.adapter.patch.config.Configurations;
 import org.sinytra.adapter.env.ctx.MixinContext;
@@ -58,6 +59,15 @@ public record ResolverSyntheticInstanceof(boolean skipInsnComparison) implements
                 if (cleanMatcher.test(dirtyMatcher)) {
                     // ModifyExpressionValue doesn't include the original instanceof call, so we can skip comparing instructions
                     if (this.skipInsnComparison) {
+                        // Only convert to @ModifyInstanceofValue if the handler returns boolean.
+                        // If it returns a non-boolean type (e.g. Block), the mixin is modifying the
+                        // value fed into the instanceof check, not the boolean result of it.
+                        // Converting in that case produces an invalid (Block)Block handler where (Z)Z is expected.
+                        Type handlerReturnType = Type.getReturnType(context.methodNode().desc);
+                        if (!handlerReturnType.equals(Type.BOOLEAN_TYPE)) {
+                            return ResolutionResult.pass();
+                        }
+
                         TypeInsnNode instanceOfInsn = (TypeInsnNode) findLabelInsns(insn).stream().filter(i -> i.getOpcode() == Opcodes.INSTANCEOF).findFirst().orElse(null);
                         if (instanceOfInsn == null) {
                             return ResolutionResult.pass();


### PR DESCRIPTION
### Problem

When a `@ModifyExpressionValue` mixin targets a method call whose result is used in a nearby `instanceof` check, `ResolverSyntheticInstanceof` (via the `skipInsnComparison` path) would unconditionally convert the annotation to `@ModifyInstanceofValue`.

This is only correct when the handler returns `boolean` (i.e. it truly modifies the boolean *result* of the instanceof check). If the handler returns a non-boolean type — because it modifies the *value fed into* the instanceof check — the conversion produces an invalid method signature like `(LBlock;)LBlock;` where `(Z)Z` is required, crashing at mixin apply time with:

```
InvalidInjectionException: @ModifyInstanceofValue ... has an invalid signature.
Found unexpected return type Block, expected boolean.
Handler signature: (LBlock;)LBlock; Expected signature: (Z)Z
```

### Reproduction

BigGlobe's `Biome_DontFreezeRiverWater` mixin uses `@ModifyExpressionValue` with handler signature `(Block)Block` targeting `BlockState.getBlock()`, whose result is then compared via `instanceof FluidBlock`. The converter sees the nearby `instanceof` and incorrectly rewrites the mixin as `@ModifyInstanceofValue`, crashing the game on bootstrap.

### Fix

Before converting, check the handler's return type via `Type.getReturnType(context.methodNode().desc)`. If it is not `boolean`, skip the conversion and return `pass()`.

### Testing

**Minecraft:** 1.21.1  
**NeoForge:** 21.1.172  

| Mod | Version |
|-----|---------|
| Connector | 2.0.0-beta.14+1.21.1 |
| ConnectorExtras | 1.12.1+1.21.1 |
| Forgified Fabric API | 0.116.7+2.2.4+1.21.1 |
| Big Globe | 5.3.1-MC1.21.1 |
| Iris (NeoForge) | 1.8.12+mc1.21.1 |
| Sodium (NeoForge) | 0.6.13+mc1.21.1 |

With the fix applied, `Biome_DontFreezeRiverWater` is correctly left as `@ModifyExpressionValue` and the game boots successfully.
