### PR TITLE
[c2me-ocl fix] Skip transform analysis for MixinExtras expressions

### DIFF
--- a/core/src/main/java/org/sinytra/adapter/env/ctx/MethodHelper.java
+++ b/core/src/main/java/org/sinytra/adapter/env/ctx/MethodHelper.java
@@ -22,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.InjectionPoint;
 import org.spongepowered.asm.mixin.injection.code.ISliceContext;
 import org.spongepowered.asm.mixin.injection.code.MethodSlice;
 import org.spongepowered.asm.mixin.injection.struct.Target;
+import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
 import org.spongepowered.asm.mixin.refmap.IMixinContext;
 import org.spongepowered.asm.util.Locals;
 
@@ -184,7 +185,13 @@ public class MethodHelper {
         // Provide a minimum implementation of IMixinContext
         IMixinContext mixinContext = MockMixinRuntime.forClass(this.context.classNode().name, target.classNode().name, patchContext.environment());
         // Parse injection point
-        InjectionPoint injectionPoint = injectionPointParser.apply(mixinContext, atNodeCopy);
+        InjectionPoint injectionPoint;
+        try {
+            injectionPoint = injectionPointParser.apply(mixinContext, atNodeCopy);
+        } catch (InvalidInjectionException e) {
+            LOGGER.debug("Skipping unsupported injection point for {}", this.context.getMixinId(), e);
+            return List.of();
+        }
         Target mixinTarget = MockMixinRuntime.createMixinTarget(target);
         // Find target instructions
         InsnList instructions = ignoreSlice ? target.methodNode().instructions : getSlicedInsns(this.context.methodAnnotation(), this.context.classNode(), this.context.methodNode(), target.classNode(), target.methodNode(), patchContext, mixinTarget);

--- a/core/src/main/java/org/sinytra/adapter/env/util/MixinAnnotationConstants.java
+++ b/core/src/main/java/org/sinytra/adapter/env/util/MixinAnnotationConstants.java
@@ -11,6 +11,7 @@ public class MixinAnnotationConstants {
     public static final String AT_VAL_STORE = "STORE";
     public static final String AT_VAL_CONST = "CONSTANT";
     public static final String AT_VAL_SINYTRA_INSTANCEOF = "sinytra:INSTANCEOF";
+    public static final String AT_VAL_MIXINEXTRAS_EXPRESSION = "MIXINEXTRAS:EXPRESSION";
     public static final String AT_SHIFT = "shift";
 
     public static final String PROPERTY_AT = "at";

--- a/core/src/main/java/org/sinytra/adapter/transform/PipelineMethodTransformer.java
+++ b/core/src/main/java/org/sinytra/adapter/transform/PipelineMethodTransformer.java
@@ -4,8 +4,8 @@ import com.mojang.logging.LogUtils;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
-import org.sinytra.adapter.env.ctx.MixinContext;
 import org.sinytra.adapter.env.ann.AtData;
+import org.sinytra.adapter.env.ctx.MixinContext;
 import org.sinytra.adapter.env.ann.SliceData;
 import org.sinytra.adapter.env.ctx.AuditTrail;
 import org.sinytra.adapter.env.ctx.PatchResult;
@@ -31,6 +31,7 @@ import org.spongepowered.asm.mixin.injection.points.BeforeConstant;
 import java.util.List;
 import java.util.Objects;
 
+import static org.sinytra.adapter.env.util.MixinAnnotationConstants.AT_VAL_MIXINEXTRAS_EXPRESSION;
 import static org.sinytra.adapter.util.AdapterUtil.MIXINPATCH;
 
 public class PipelineMethodTransformer implements MethodTransformer {
@@ -46,6 +47,11 @@ public class PipelineMethodTransformer implements MethodTransformer {
 
     @Override
     public PatchResult apply(MixinContext context, Configuration config) {
+        if (hasMixinExtrasExpressionInjectionPoint(config)) {
+            LOGGER.debug(MIXINPATCH, "Skipping MixinExtras expression injection point for {}", context.getMixinId());
+            return PatchResult.PASS;
+        }
+
         TargetPair cleanTarget = context.methods().findOwnMethodPair(context.cleanLookup(), config.getTargetMethod());
         if (cleanTarget == null) return PatchResult.PASS;
 
@@ -184,5 +190,10 @@ public class PipelineMethodTransformer implements MethodTransformer {
             true
         );
         return !insns.isEmpty();
+    }
+
+    private static boolean hasMixinExtrasExpressionInjectionPoint(Configuration config) {
+        AtData atData = config.getAtData();
+        return atData != null && AT_VAL_MIXINEXTRAS_EXPRESSION.equals(atData.getValue());
     }
 }


### PR DESCRIPTION
## The Issue

The new C2ME OpenCl build for 1.21.1 is borked with NeoForge

## The Proposal

Kinda skip transforming MIXINEXTRAS:EXPRESSION

## Possible Side Effects

It's generally kinda bad and targeted for 1 mod, but shouldn't cause any issues with mods that worked before

## Alternatives

It's a patch for 1 mod T_T. idk

## Additional Notes
The new OpenCl accel is very very cool so if you would make some changes to make the code to your liking it would be very awesome