### PR TITLE
Support no-refmap method patches and ModifyConstant injectors

### DIFF
--- a/core/src/main/java/org/sinytra/adapter/env/ann/ConstantData.java
+++ b/core/src/main/java/org/sinytra/adapter/env/ann/ConstantData.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public class ConstantData {
     private static final PropertyContainerTemplate TEMPLATE = PropertyContainerTemplate.builder()
-        .requireOne(Keys.DOUBLE_VALUE, Keys.CLASS_VALUE)
+        .requireOne(Keys.INT_VALUE, Keys.DOUBLE_VALUE, Keys.CLASS_VALUE)
         .build();
 
     private final PropertyContainer properties;
@@ -47,6 +47,7 @@ public class ConstantData {
     }
 
     public static class Keys {
+        public static final PropertyKey<Integer> INT_VALUE = PropertyKey.create("intValue", Integer.class);
         public static final PropertyKey<Double> DOUBLE_VALUE = PropertyKey.create("doubleValue", Double.class);
         public static final PropertyKey<Type> CLASS_VALUE = PropertyKey.create("classValue", Type.class);
     }

--- a/core/src/main/java/org/sinytra/adapter/patch/mixin/MixinTypes.java
+++ b/core/src/main/java/org/sinytra/adapter/patch/mixin/MixinTypes.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.Nullable;
 import org.sinytra.adapter.env.util.MixinAnnotations;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
@@ -14,12 +15,13 @@ public class MixinTypes {
     private static final Map<String, MixinType> MIXIN_TYPES = new HashMap<>();
     
     // TODO:
-    // MixinConstants.MODIFY_ARGS, MixinConstants.MODIFY_CONST, MixinConstants.WRAP_WITH_CONDITION,
+    // MixinConstants.MODIFY_ARGS, MixinConstants.WRAP_WITH_CONDITION,
     // MixinConstants.OVERWRITE (dont forget special modifyTarget handling)
     // MixinConstants.ACCESSOR
     public static final MixinType INJECT = new InjectMixin();
     public static final MixinType MODIFY_VAR = new ModifyVariableMixin();
     public static final MixinType MODIFY_ARG = new ModifyArgMixin();
+    public static final MixinType MODIFY_CONST = new ModifyConstantMixin();
     public static final MixinType MODIFY_RET = new ModifyReturnValueMixin();
     public static final MixinType REDIRECT = new RedirectMixin();
     public static final MixinType WRAP_OP = new WrapOperationMixin();
@@ -29,6 +31,7 @@ public class MixinTypes {
         registerMixinType(Inject.class, INJECT);
         registerMixinType(ModifyVariable.class, MODIFY_VAR);
         registerMixinType(ModifyArg.class, MODIFY_ARG);
+        registerMixinType(ModifyConstant.class, MODIFY_CONST);
         registerMixinType(MixinAnnotations.MODIFY_RETURN_VAL_INTERNAL_NAME, MODIFY_RET);
         registerMixinType(Redirect.class, REDIRECT);
         registerMixinType(MixinAnnotations.WRAP_OPERATION_INTERNAL_NAME, WRAP_OP);

--- a/core/src/main/java/org/sinytra/adapter/patch/mixin/ModifyConstantMixin.java
+++ b/core/src/main/java/org/sinytra/adapter/patch/mixin/ModifyConstantMixin.java
@@ -1,0 +1,55 @@
+package org.sinytra.adapter.patch.mixin;
+
+import org.sinytra.adapter.env.ctx.MixinContext;
+import org.sinytra.adapter.env.param.MethodParameters;
+import org.sinytra.adapter.patch.Recipe;
+import org.sinytra.adapter.patch.TxResult;
+import org.sinytra.adapter.patch.config.Configuration;
+import org.sinytra.adapter.patch.config.ConfigurationTemplates;
+import org.sinytra.adapter.patch.config.MutableConfiguration;
+import org.sinytra.adapter.patch.config.PropertyContainerTemplate;
+import org.sinytra.adapter.patch.config.key.MixinKeys;
+import org.sinytra.adapter.patch.processor.Processors;
+import org.sinytra.adapter.patch.resolver.Resolvers;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.sinytra.adapter.env.param.MethodParameters.ParamGroup.CAPTURED_PARAMS;
+import static org.sinytra.adapter.env.param.MethodParameters.ParamGroup.SINGLE_ANY;
+
+public class ModifyConstantMixin implements MixinType {
+    private static final PropertyContainerTemplate TEMPLATE = ConfigurationTemplates.MIXIN_BASE.extend()
+        .require(MixinKeys.TARGET_CONSTANT)
+        .pluralKeys(MixinKeys.TARGET_METHOD, MixinKeys.TARGET_CONSTANT)
+        .build();
+
+    @Override
+    public PropertyContainerTemplate getConfigurationTemplate() {
+        return TEMPLATE;
+    }
+
+    @Override
+    public Set<MixinFlag> getFlags() {
+        return EnumSet.of(MixinFlag.RETURN_TYPE_SENSITIVE);
+    }
+
+    @Override
+    public TxResult preProcess(MixinContext context, MutableConfiguration clean, Resolvers resolvers, Processors processors) {
+        clean.setParameters(MethodParameters.create(context.methodNode(), List.of(SINGLE_ANY, CAPTURED_PARAMS)));
+        return TxResult.SUCCESS;
+    }
+
+    @Override
+    public TxResult postProcess(MixinContext context, Configuration clean, MutableConfiguration dirty, Recipe recipe) {
+        if (dirty.getTargetMethod() == null) {
+            return TxResult.FAIL;
+        }
+
+        dirty.inheritProperyIfAbsent(MixinKeys.TARGET_CONSTANT);
+        dirty.inheritParameters();
+        dirty.inheritReturnType();
+        return TxResult.SUCCESS;
+    }
+}

--- a/core/src/main/java/org/sinytra/adapter/patch/resolver/injection/InjectionPointResolver.java
+++ b/core/src/main/java/org/sinytra/adapter/patch/resolver/injection/InjectionPointResolver.java
@@ -6,6 +6,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.sinytra.adapter.env.ctx.MixinContext;
 import org.sinytra.adapter.patch.Recipe;
 import org.sinytra.adapter.patch.config.Configuration;
+import org.sinytra.adapter.patch.config.key.MixinKeys;
 import org.sinytra.adapter.patch.resolver.CompoundResolver;
 import org.sinytra.adapter.env.ctx.TargetPair;
 import org.sinytra.adapter.util.MethodQualifier;
@@ -24,7 +25,8 @@ public class InjectionPointResolver extends CompoundResolver {
 
     @Override
     protected boolean canApply(Recipe recipe) {
-        return recipe.dirty().getAtData() == null;
+        return recipe.dirty().getAtData() == null
+            && !recipe.clean().hasProperty(MixinKeys.TARGET_CONSTANT);
     }
 
     @Nullable

--- a/core/src/main/java/org/sinytra/adapter/transform/PipelineMethodTransformer.java
+++ b/core/src/main/java/org/sinytra/adapter/transform/PipelineMethodTransformer.java
@@ -46,11 +46,12 @@ public class PipelineMethodTransformer implements MethodTransformer {
 
     @Override
     public PatchResult apply(MixinContext context, Configuration config) {
+        boolean hasManualPatch = this.patchResolver.matches(config);
         TargetPair cleanTarget = context.methods().findOwnMethodPair(context.cleanLookup(), config.getTargetMethod());
-        if (cleanTarget == null) return PatchResult.PASS;
+        if (cleanTarget == null && !hasManualPatch) return PatchResult.PASS;
 
         TargetPair dirtyTarget = context.methods().findOwnMethodPair(context.dirtyLookup(), config.getTargetMethod());
-        if (!this.patchResolver.matches(config) && !failsDirtyInjectionCheck(context, config, dirtyTarget) && hasValidSlice(context, config, dirtyTarget))
+        if (!hasManualPatch && !failsDirtyInjectionCheck(context, config, dirtyTarget) && hasValidSlice(context, config, dirtyTarget))
             return PatchResult.PASS;
 
         LOGGER.debug(MIXINPATCH, "Considering method {}", context.getMixinId());

--- a/core/src/main/java/org/sinytra/adapter/transform/patch/MethodPatchBuilder.java
+++ b/core/src/main/java/org/sinytra/adapter/transform/patch/MethodPatchBuilder.java
@@ -30,6 +30,10 @@ public interface MethodPatchBuilder {
     
     MethodPatchBuilder modifyTarget(String method);
 
+    MethodPatchBuilder modifyOrdinal(int ordinal);
+
+    MethodPatchBuilder modifyInjectionPointOrdinal(int ordinal);
+
     MethodPatchBuilder modifyInjectionPoint(String target);
 
     MethodPatchBuilder modifyInjectionPoint(String value, String target);

--- a/core/src/main/java/org/sinytra/adapter/transform/patch/MethodPatchBuilderImpl.java
+++ b/core/src/main/java/org/sinytra/adapter/transform/patch/MethodPatchBuilderImpl.java
@@ -110,6 +110,21 @@ public class MethodPatchBuilderImpl implements MethodPatchBuilder {
     }
 
     @Override
+    public MethodPatchBuilder modifyOrdinal(int ordinal) {
+        this.config.setProperty(MixinKeys.ORDINAL, ordinal);
+        return this;
+    }
+
+    @Override
+    public MethodPatchBuilder modifyInjectionPointOrdinal(int ordinal) {
+        this.configCompleter = this.configCompleter.andThen((clean, dirty) -> {
+            AtData at = dirty.getAtData() == null ? clean.getAtData() : dirty.getAtData();
+            dirty.setAtData(at.withOrdinal(ordinal));
+        });
+        return this;
+    }
+
+    @Override
     public MethodPatchBuilder modifyInjectionPoint(String target) {
         // AtData requires value which must be copied at transform time
         this.configCompleter = this.configCompleter.andThen((clean, dirty) ->

--- a/test/mc-26.1.2/src/test/java/org/sinytra/adapter/patch/test/mc_26_1_2/mixin/DynamicMixinPatchTest.java
+++ b/test/mc-26.1.2/src/test/java/org/sinytra/adapter/patch/test/mc_26_1_2/mixin/DynamicMixinPatchTest.java
@@ -10,12 +10,15 @@ import org.sinytra.adapter.env.ctx.RefmapHolder;
 import org.sinytra.adapter.patch.DynamicPatches;
 import org.sinytra.adapter.patch.Patcher;
 import org.sinytra.adapter.patch.test_main.mixin.MinecraftMixinPatchTest;
+import org.sinytra.adapter.transform.patch.MethodPatch;
 import org.sinytra.adapter.types.FieldTypeUsageTransformer;
 import org.sinytra.adapter.util.provider.ClassLookup;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.FabricUtil;
 
 import java.util.List;
+
+import static org.sinytra.adapter.env.util.MixinAnnotations.MODIFY_CONST;
 
 public class DynamicMixinPatchTest extends MinecraftMixinPatchTest {
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -45,7 +48,14 @@ public class DynamicMixinPatchTest extends MinecraftMixinPatchTest {
         );
         patcher = Patcher.builder(patchEnvironment)
             .classTransformer(new FieldTypeUsageTransformer())
-            .methodTransformers(DynamicPatches.methodTransformers(List.of()))
+            .methodTransformers(DynamicPatches.methodTransformers(List.of(
+                MethodPatch.builder()
+                    .targetClass("net/minecraft/world/inventory/AnvilMenu")
+                    .targetMethod("createResult")
+                    .targetMixinType(MODIFY_CONST)
+                    .modifyTarget("createResultInternal")
+                    .build()
+            )))
             .build();
     }
 
@@ -61,6 +71,21 @@ public class DynamicMixinPatchTest extends MinecraftMixinPatchTest {
             "playSoundCorrectlyForBlocks",
             "org/sinytra/adapter/test/mc_26_1_2/mixin/adapter_generated_IBlockExtension",
             assertTargetMethod()
+        );
+    }
+
+    /**
+     * Reproduces Origins Classes' efficient-repairs mixin, whose integer
+     * {@code @ModifyConstant} target moves from {@code AnvilMenu#createResult}
+     * to NeoForge's {@code AnvilMenu#createResultInternal}.
+     */
+    @Test
+    void testModifyConstantTarget() throws Exception {
+        assertSameCode(
+            "org/sinytra/adapter/test/mc_26_1_2/mixin/AnvilMenuMixin",
+            "halfRepairMaterialCost",
+            assertTargetMethod(),
+            assertTargetsConstant()
         );
     }
 

--- a/test/mc-26.1.2/src/testClasses/java/org/sinytra/adapter/test/mc_26_1_2/mixin/AnvilMenuMixin.java
+++ b/test/mc-26.1.2/src/testClasses/java/org/sinytra/adapter/test/mc_26_1_2/mixin/AnvilMenuMixin.java
@@ -1,0 +1,29 @@
+package org.sinytra.adapter.test.mc_26_1_2.mixin;
+
+import net.minecraft.world.inventory.AnvilMenu;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+/**
+ * Equivalent of the Origins Classes efficient-repairs mixin used to verify
+ * retargeting an integer {@link ModifyConstant} injector for NeoForge.
+ */
+@Mixin(AnvilMenu.class)
+public class AnvilMenuMixin {
+    @ModifyConstant(
+        method = "createResult",
+        constant = @Constant(intValue = 4, ordinal = 0)
+    )
+    private int halfRepairMaterialCost(int original) {
+        return original / 2;
+    }
+
+    @ModifyConstant(
+        method = "createResultInternal",
+        constant = @Constant(intValue = 4)
+    )
+    private int halfRepairMaterialCostExpected(int original) {
+        return original / 2;
+    }
+}

--- a/test/src/test/java/org/sinytra/adapter/patch/test/MethodPatchExtensionTest.java
+++ b/test/src/test/java/org/sinytra/adapter/patch/test/MethodPatchExtensionTest.java
@@ -1,0 +1,39 @@
+package org.sinytra.adapter.patch.test;
+
+import org.junit.jupiter.api.Test;
+import org.sinytra.adapter.env.ann.AtData;
+import org.sinytra.adapter.patch.config.MutableConfiguration;
+import org.sinytra.adapter.patch.config.key.MixinKeys;
+import org.sinytra.adapter.patch.mixin.MixinTypes;
+import org.sinytra.adapter.transform.patch.MethodPatch;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class MethodPatchExtensionTest {
+    @Test
+    void recognizesModifyConstantMixins() {
+        assertSame(
+            MixinTypes.MODIFY_CONST,
+            MixinTypes.getMixinType(ModifyConstant.class.getName().replace('.', '/'))
+        );
+    }
+
+    @Test
+    void updatesMethodAndInjectionPointOrdinalsTogether() {
+        MethodPatch patch = MethodPatch.builder()
+            .modifyOrdinal(3)
+            .modifyInjectionPointOrdinal(1)
+            .build();
+        MutableConfiguration clean = MutableConfiguration.create()
+            .setAtData(AtData.builder("INVOKE").target("Lexample/Target;call()V").build());
+        MutableConfiguration dirty = MutableConfiguration.create();
+
+        patch.configCompleter().accept(clean, dirty);
+
+        assertEquals(3, patch.configuration().getProperty(MixinKeys.ORDINAL).orElseThrow());
+        assertEquals(1, dirty.getAtData().getOrdinal().orElseThrow());
+        assertEquals("Lexample/Target;call()V", dirty.getAtData().getTargetOrThrow());
+    }
+}

--- a/test/src/test/java/org/sinytra/adapter/patch/test/MethodPatchExtensionTest.java
+++ b/test/src/test/java/org/sinytra/adapter/patch/test/MethodPatchExtensionTest.java
@@ -11,7 +11,14 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+/**
+ * Tests extension points used by explicit platform compatibility patches.
+ */
 class MethodPatchExtensionTest {
+    /**
+     * Verifies that standard {@link ModifyConstant} injectors are dispatched to
+     * the configuration model that resolves their nested {@code @Constant} target.
+     */
     @Test
     void recognizesModifyConstantMixins() {
         assertSame(
@@ -20,6 +27,10 @@ class MethodPatchExtensionTest {
         );
     }
 
+    /**
+     * Verifies that an injector ordinal and its nested injection-point ordinal can
+     * be changed independently without either update discarding the other.
+     */
     @Test
     void updatesMethodAndInjectionPointOrdinalsTogether() {
         MethodPatch patch = MethodPatch.builder()


### PR DESCRIPTION
## The Issue

Adapter currently skips method transformations when it cannot resolve the mixin's clean target method. This prevents explicitly configured compatibility patches from running for Fabric mods that omit a usable refmap, even when the patch precisely matches the mixin annotation and supplies the required replacement.

Adapter also lacks a mixin model for `@ModifyConstant`. As a result, these injectors cannot be adapted when their target method moves between Minecraft and NeoForge. Integer constants are not represented by `ConstantData`, further limiting constant-injector matching.

Finally, the method-patch API cannot independently modify an injector's `ordinal` and its nested `@At.ordinal`. These are separate annotation properties and may both require adjustment after target bytecode changes.

These limitations were encountered while adapting Origins: Legacy to Minecraft 26.1.2 through Connector.

## The Proposal

This change expands Adapter's generic method-patching capabilities:

- Adds a `ModifyConstantMixin` model and registers `@ModifyConstant` as a supported mixin type.
- Adds integer constant support to `ConstantData`.
- Prevents the generic injection-point resolver from handling constant injectors before `TARGET_CONSTANT` has been inherited.
- Allows an explicitly matched manual patch to run when the clean target method cannot be resolved.
- Adds separate method-patch operations for modifying the injector `ordinal` and nested injection-point `@At.ordinal`.
- Makes injection-point ordinal changes compose with earlier injection-point target changes.
- Adds regression coverage for `@ModifyConstant` recognition and simultaneous injector/injection-point ordinal changes.

Explicit patches still have to match their configured target class, target method, mixin type, and other supplied annotation properties.

## Possible Side Effects

Explicit manual patches can now run in cases where no clean target method is available. A stale or overly broad manual patch could therefore be attempted where Adapter previously returned early.

This risk is limited by the existing patch matcher and dirty-configuration validation. The fallback applies only when an explicitly registered patch matches; automatic resolution behavior remains unchanged when no manual patch is present.

Registering `@ModifyConstant` means these injectors now enter the normal Adapter processing pipeline instead of remaining unsupported. This may expose existing constant injectors to transformations that were previously skipped.

No material performance impact is expected. The additional matching and configuration work occurs only during mod transformation.

## Alternatives

One alternative was to implement each affected transformation as a mod-specific bytecode rewrite in Connector. This was not selected because missing `@ModifyConstant` support and independent ordinal editing are general Adapter capabilities that can benefit other Fabric mod adaptations.

Another option was to generate or fabricate refmap information for mods that do not provide it. That would introduce inferred mapping data and could cause Adapter to select an incorrect clean target.

Disabling the affected mixins was also considered. This would allow startup in some cases but could remove intended mod behavior and produce a false compatibility result.

A final alternative was to retarget only the affected methods without adding a `@ModifyConstant` model. That would not provide the configuration and parameter handling required to transform constant injectors safely.

## Additional Notes

Validation completed successfully:

- Adapter unit suite: 31 tests passed.
- Minecraft 26.1.2 Adapter integration suite: passed.
- Connector transformer regression suite using the updated Adapter: passed.
- A cold dedicated-server transformation of Origins: Legacy 1.12.15 for Minecraft 26.1.2 reached the server-ready marker and shut down cleanly.